### PR TITLE
Use pythoncapi-compat when possible

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
+[submodule "pythoncapi-compat"]
+	path = src/c/pythoncapi-compat
+	url = https://github.com/python/pythoncapi-compat
 [submodule "zstd"]
 	path = src/c/zstd
 	url = https://github.com/facebook/zstd.git

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,8 @@
 recursive-include src *
 recursive-include tests *
+recursive-exclude src/c/pythoncapi-compat *
+include src/c/pythoncapi-compat/COPYING
+include src/c/pythoncapi-compat/pythoncapi_compat.h
 recursive-exclude src/c/zstd *
 include src/c/zstd/COPYING
 include src/c/zstd/LICENSE

--- a/setup.py
+++ b/setup.py
@@ -27,9 +27,10 @@ setup(
                 *locate_sources("src", "c", "zstd", "lib", "dictBuilder"),
             ],
             include_dirs=[
+                "src/c/compat",
                 "src/c/compression_zstd",
                 "src/c/compression_zstd/clinic",
-                "src/c/compat",
+                "src/c/pythoncapi-compat",
                 "src/c/zstd/lib",
                 "src/c/zstd/lib/common",
                 "src/c/zstd/lib/dictBuilder",

--- a/src/c/compat/backports_zstd_compat.h
+++ b/src/c/compat/backports_zstd_compat.h
@@ -3,27 +3,14 @@
 
 #include "Python.h"
 
+#include "pythoncapi_compat.h"
+
 #if PY_VERSION_HEX < 0x030D0000 // Python 3.12 and below
 #define Py_mod_gil 0
 #define Py_MOD_GIL_NOT_USED NULL
-#define PyLong_AsInt _PyLong_AsInt
-#define Py_BEGIN_CRITICAL_SECTION(op) {
-#define Py_END_CRITICAL_SECTION() }
-#define Py_BEGIN_CRITICAL_SECTION2(a, b) {
-#define Py_END_CRITICAL_SECTION2() }
-#endif
-
-#if PY_VERSION_HEX < 0x030C0000 // Python 3.11 and below
-#include "structmember.h"
-#define Py_T_INT T_INT
-#define Py_T_UINT T_UINT
-#define Py_T_BOOL T_BOOL
-#define Py_T_OBJECT_EX T_OBJECT_EX
-#define Py_READONLY READONLY
 #endif
 
 #if PY_VERSION_HEX < 0x030B0000 // Python 3.10 and below
-#define _Py_CAST(type, expr) ((type)(expr))
 #define _PyCFunction_CAST(func) _Py_CAST(PyCFunction, _Py_CAST(void (*)(void), (func)))
 PyAPI_FUNC(PyObject *) PyType_GetModuleByDef(PyTypeObject *, PyModuleDef *);
 #endif


### PR DESCRIPTION
Let's use a well-known project for compat as much as possible.

This will be helpful when switching upstream code to 3.14.0b2, as newer C-APIs are used.