### PR TITLE
Include zstd license in wheel distributions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ __pycache__
 *.egg-info
 *.o
 *.so
+
+/LICENSE_zstd.txt

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -4,6 +4,5 @@ recursive-exclude src/c/pythoncapi-compat *
 include src/c/pythoncapi-compat/COPYING
 include src/c/pythoncapi-compat/pythoncapi_compat.h
 recursive-exclude src/c/zstd *
-include src/c/zstd/COPYING
 include src/c/zstd/LICENSE
 recursive-include src/c/zstd/lib *

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ description = "Backport of compression.zstd"
 readme = { file = "README.md", content-type = "text/markdown" }
 keywords = ["backport", "backports", "pep-784", "zstd"]
 license = "PSF-2.0"
-license-files = ["LICENSE.txt"]
+license-files = ["LICENSE.txt", "LICENSE_zstd.txt"]
 classifiers = [
     "Development Status :: 2 - Pre-Alpha",
     "Intended Audience :: Developers",

--- a/setup.py
+++ b/setup.py
@@ -4,6 +4,19 @@ from pathlib import Path
 import sysconfig
 
 
+# create a LICENSE_zstd.txt file
+# wheels distributions needs to ship the license of the zstd library
+ROOT_PATH = Path(__file__).parent.absolute()
+with (ROOT_PATH / "LICENSE_zstd.txt").open("w") as f:
+    f.write(
+        "Depending on how it is build, this package may distribute the zstd library,\n"
+        "partially or in its integrality, in source or binary form.\n\n"
+        "Its license is reproduced below.\n\n"
+        "---\n\n"
+    )
+    f.write((ROOT_PATH / "src" / "c" / "zstd" / "LICENSE").read_text())
+
+
 UnixCCompiler.src_extensions.append(".S")
 
 _PLATFORM_IS_WIN = sysconfig.get_platform().startswith("win")


### PR DESCRIPTION
The sdist distributions already include the license of the zstd library. However, the wheels did not.

This is an issue because said license explicitly asks to distribute the license together with the binary.

See https://github.com/Rogdham/pyzstd/issues/42 for more context and previous work on the topic.