### PR TITLE
Import tarfile/zipfile modules only when needed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/), and this project
 adheres to [Semantic Versioning](https://semver.org/).
 
+## Unreleased
+
+### :bug: Fixes
+
+- Fix import order issue by importing the `tarfile` and `zipfile` modules only when
+  needed.
+
 ## [0.5.0] - 2025-08-17
 
 [0.5.0]: https://github.com/rogdham/backports.zstd/releases/tag/v0.5.0

--- a/src/python/backports/zstd/_shutil.py
+++ b/src/python/backports/zstd/_shutil.py
@@ -13,8 +13,6 @@ from shutil import (
     unregister_unpack_format,
 )
 
-from backports.zstd import tarfile, zipfile
-
 try:
     import zlib
     del zlib
@@ -96,6 +94,8 @@ def _make_tarball(base_name, base_dir, compress="gzip", verbose=0, dry_run=0,
         return tarinfo
 
     if not dry_run:
+        from backports.zstd import tarfile
+
         tar = tarfile.open(archive_name, 'w|%s' % tar_compression)
         arcname = base_dir
         if root_dir is not None:
@@ -114,6 +114,8 @@ _make_tarball.supports_root_dir = True
 def _unpack_zipfile(filename, extract_dir):
     """Unpack zip `filename` to `extract_dir`
     """
+    from backports.zstd import zipfile
+
     if not zipfile.is_zipfile(filename):
         raise ReadError("%s is not a zip file" % filename)
 
@@ -142,6 +144,8 @@ def _unpack_zipfile(filename, extract_dir):
 def _unpack_tarfile(filename, extract_dir, *, filter=None):
     """Unpack tar/tar.gz/tar.bz2/tar.xz/tar.zst `filename` to `extract_dir`
     """
+    from backports.zstd import tarfile
+
     try:
         tarobj = tarfile.open(filename)
     except tarfile.TarError:


### PR DESCRIPTION
Fixes #41; see the ticket for more info on the issue.

Also this prevents the 2 modules from being imported together with `backports.zstd`, which should make the import somewhat faster for users not interested in `tarfile`/`zipfile`/`shutil` support.

Running `python -v -m backports.zstd 2>&1 |grep '^import' | grep backports` comfirms this:
 - before the PR:
    - `import 'backports'`
    - `import 'backports.zstd._zstd'`
    - `import 'backports.zstd.tarfile'`
    - `import 'backports.zstd.zipfile._path.glob'`
    - `import 'backports.zstd.zipfile._path'`
    - `import 'backports.zstd.zipfile'`
    - `import 'backports.zstd._shutil'`
    - `import 'backports.zstd._streams'`
    - `import 'backports.zstd._zstdfile'`
    - `import 'backports.zstd'`
 - after the PR:
    - `import 'backports'`
    - `import 'backports.zstd._zstd'`
    - `import 'backports.zstd._shutil'`
    - `import 'backports.zstd._streams'`
    - `import 'backports.zstd._zstdfile'`
    - `import 'backports.zstd'`