### PR TITLE
Support dynamic linking to libzstd

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -78,10 +78,8 @@ jobs:
           FULL = os.environ["FULL"] == "1"
           CASES = []
 
-
           def add(name, platform, archs, build, qemu=False):
               CASES.append(locals())
-
 
           for identifier in ("manylinux", "musllinux"):
               build = " ".join(f"{py}-{identifier}_*" for py in PYTHON_VERSIONS if identifier=="manylinux" or py.startswith("cp"))
@@ -178,6 +176,55 @@ jobs:
       - name: Test
         run: python -m unittest discover tests -v
 
+  test_system_zstd:
+    name:
+      Test system zstd | ${{ matrix.pypy && 'PyPy' || 'CPython' }} ${{ matrix.system &&
+      'system' || 'distributed' }}
+    runs-on: ubuntu-latest
+    needs:
+      - build_sdist
+    strategy:
+      fail-fast: false
+      matrix:
+        pypy: [false, true]
+        system: [false, true]
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "${{ matrix.pypy && 'pypy3.11' || '3.13' }}"
+      - name: Restore build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: sdist
+          path: dist
+      - name: Install package
+        run:
+          python -m pip install ${{ matrix.system &&
+          '--config-settings=--build-option=--system-zstd' || '' }} dist/*.tar.gz
+      - name: Check dynamic libraries requirements
+        shell: python
+        run: |
+          from backports import zstd
+          import inspect
+          import subprocess
+          import sys
+
+          filename = inspect.getfile(zstd.${{ matrix.pypy && '_zstd_cffi' || '_zstd' }})
+          ldd_out = subprocess.check_output(["ldd", filename], text=True)
+          print(ldd_out)
+
+          expected_zstd = ${{ matrix.system && 'True' || 'False' }}
+          got_zstd = "zstd" in ldd_out
+          sys.exit(got_zstd != expected_zstd)
+      - name: Test
+        run: python -m unittest discover tests -v
+        env:
+          BACKPORTSZSTD_SKIP_EXTENSION_TEST: "${{ matrix.system && '1' || '0' }}"
+
   test_typing:
     name: Test typing | ${{ matrix.kind }}
     runs-on: ubuntu-latest
@@ -225,6 +272,7 @@ jobs:
       - build_wheels
       - test_integration
       - test_specific_python_versions
+      - test_system_zstd
       - test_typing
     environment: publish
     permissions:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ adheres to [Semantic Versioning](https://semver.org/).
 ### :rocket: Added
 
 - Update code with CPython 3.14.0 release candidate 3 version
+- Allow to use `libzstd` present on the system with the `--system-zstd` build backend
+  argument
+- Check the `libzstd` version during build and at runtime
 
 ### :bug: Fixes
 

--- a/README.md
+++ b/README.md
@@ -174,6 +174,23 @@ However, this library can be used without waiting. At this point, `backports.zst
 considered feature-complete, with support for CPython 3.9 to 3.13 (including
 free-threading support for 3.13).
 
+### Can I use the libzstd version installed on my system?
+
+The wheels distributed on PyPI include a static version of `libzstd` for ease of
+installation and reproducibility.
+
+If you want to use `libzstd` installed on your system, pass the `--system-zstd` argument
+to the build backend. For example:
+
+```sh
+python -m pip install --config-settings=--build-option=--system-zstd ...
+python -m build --wheel --config-setting=--build-option=--system-zstd ...
+```
+
+If you run the test suite, set the environment variable
+`BACKPORTSZSTD_SKIP_EXTENSION_TEST=1` to skip tests that may fail when using the system
+library.
+
 ### I found a bug
 
 If you encounter any issues, please open a

--- a/src/c/compat/backports_zstd_compat.h
+++ b/src/c/compat/backports_zstd_compat.h
@@ -2,8 +2,13 @@
 #define BACKPORTS_ZSTD_COMPAT_H
 
 #include "Python.h"
+#include <zstd.h>
 
 #include "pythoncapi_compat.h"
+
+#if ZSTD_VERSION_NUMBER < 10405
+#error "zstd version is too old"
+#endif
 
 #if PY_VERSION_HEX < 0x030E0000 // Python 3.13 and below
 static inline int PyType_Freeze(PyTypeObject *type)

--- a/src/python/backports/zstd/__init__.py
+++ b/src/python/backports/zstd/__init__.py
@@ -41,6 +41,9 @@ zstd_version_info = (*divmod(_zstd.zstd_version_number // 100, 100),
                      _zstd.zstd_version_number % 100)
 """Version number of the runtime zstd library as a tuple of integers."""
 
+if zstd_version_info < (1, 4, 5):
+    raise RuntimeError("zstd version is too old")
+
 COMPRESSION_LEVEL_DEFAULT = _zstd.ZSTD_CLEVEL_DEFAULT
 """The default compression level for Zstandard, currently '3'."""
 

--- a/tests/test_extension.py
+++ b/tests/test_extension.py
@@ -1,7 +1,12 @@
+import os
 import unittest
 from backports import zstd
 
 
+@unittest.skipIf(
+    os.environ.get("BACKPORTSZSTD_SKIP_EXTENSION_TEST") == "1",
+    "BACKPORTSZSTD_SKIP_EXTENSION_TEST set",
+)
 class TestExtension(unittest.TestCase):
     def test_multithreading_support(self):
         self.assertFalse(zstd.CompressionParameter.nb_workers.bounds() == (0, 0))


### PR DESCRIPTION
Add the `--system-zstd` build backend argument to link dynamically to local version of `libzstd`.

This is expected to be wanted by downstream packagers.
