### PR TITLE
Drop support for PyPy 3.9

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,7 +62,7 @@ jobs:
       matrix: ${{ steps.define.outputs.matrix }}
       full: ${{ steps.define.outputs.full }}
     env:
-      PYTHON_VERSIONS: cp39 cp310 cp311 cp312 cp313 cp313t pp310 pp311
+      PYTHON_VERSIONS: cp310 cp311 cp312 cp313 cp313t pp310 pp311
       FULL:
         ${{ ( startsWith(github.ref, 'refs/tags') || startsWith(github.head_ref,
         'release-') || github.event_name == 'workflow_dispatch' ) && '1' || '0' }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ adheres to [Semantic Versioning](https://semver.org/).
 ### :rocket: Added
 
 - Update code with CPython 3.14.0 release candidate 3 version
+- End of support for PyPy 3.9
 
 ### :bug: Fixes
 


### PR DESCRIPTION
PyPy 3.9 reached end of life in August 2024 with [PyPy version 7.3.17](https://pypy.org/posts/2024/08/pypy-v7317-release.html#pypy-versions-and-speed-pypy-org).