### PR TITLE
Fix PyPy build for EOL versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -115,7 +115,7 @@ jobs:
     env:
       CIBW_ARCHS: ${{ matrix.archs }}
       CIBW_BUILD: ${{ matrix.build }}
-      CIBW_ENABLE: cpython-freethreading pypy
+      CIBW_ENABLE: cpython-freethreading pypy pypy-eol
       CIBW_TEST_COMMAND: python -m unittest discover {project}/tests -v
     steps:
       - name: Setup Python


### PR DESCRIPTION
History:
 - February 2025: [PyPy 7.3.19](https://pypy.org/posts/2025/02/pypy-v7319-release.html) had 3.11 in beta.
 - July 2025: [PyPy 7.3.20](https://pypy.org/posts/2025/07/pypy-v7320-release.html) removed the beta flag from 3.11, and dropped support for 3.10

Dropping support for PyPy 7.3.19 seems a bit premature as a result.

Let's still build wheels for 3.9 and 3.10 for now.