### PR TITLE
Update code from upstream 3.14.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.14.0-rc.3"
+          python-version: "3.14"
       - name: Test
         run: python tests/test_integration.py
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ adheres to [Semantic Versioning](https://semver.org/).
 
 ### :rocket: Added
 
-- Update code with CPython 3.14.0 release candidate 3 version
+- Update code with CPython 3.14.0 version
 - Update type hints with typeshed `aa5202465`
 - Update `pythoncapi-compat` dependency
 - Allow to use `libzstd` present on the system with the `--system-zstd` build backend

--- a/README.md
+++ b/README.md
@@ -164,16 +164,6 @@ usage of this library based on the Python version:
 - [During install](#install);
 - [When importing at runtime](#usage).
 
-### What is the status of `backports.zstd`?
-
-The code currently comes from CPython 3.14.0rc3. As a result, changes may appear
-upstream as we get closer to the final 3.14.0 release. We plan on releasing version
-1.0.0 of `backports.zstd` together with release 3.14.0 of CPython.
-
-However, this library can be used without waiting. At this point, `backports.zstd` is
-considered feature-complete, with support for CPython 3.9 to 3.13 (including
-free-threading support for 3.13).
-
 ### Can I use the libzstd version installed on my system?
 
 The wheels distributed on PyPI include a static version of `libzstd` for ease of

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ keywords = ["backport", "backports", "pep-784", "zstd"]
 license = "PSF-2.0"
 license-files = ["LICENSE.txt", "LICENSE_zstd.txt"]
 classifiers = [
-    "Development Status :: 4 - Beta",
+    "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Developers",
     "Topic :: System :: Archiving :: Compression",
     "Programming Language :: Python",

--- a/tests/test/support/__init__.py
+++ b/tests/test/support/__init__.py
@@ -310,6 +310,16 @@ def requires(resource, msg=None):
     if resource == 'gui' and not _is_gui_available():
         raise ResourceDenied(_is_gui_available.reason)
 
+def _get_kernel_version(sysname="Linux"):
+    import platform
+    if platform.system() != sysname:
+        return None
+    version_txt = platform.release().split('-', 1)[0]
+    try:
+        return tuple(map(int, version_txt.split('.')))
+    except ValueError:
+        return None
+
 def _requires_unix_version(sysname, min_version):
     """Decorator raising SkipTest if the OS is `sysname` and the version is less
     than `min_version`.


### PR DESCRIPTION
Python 3.14 is officially released :partying_face: 

As expected, almost no changes since 3.14.0rc3.