### PR TITLE
Lazy-load register_shutil

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ adheres to [Semantic Versioning](https://semver.org/).
 
 ## Unreleased
 
+### :rocket: Added
+
+- Shorten import time by lazy loading the `register_shutil` function
+
 ### :bug: Fixes
 
 - Fix assertion on Python 3.13 when build with `DEBUG`

--- a/src/python/backports/zstd/__init__.py
+++ b/src/python/backports/zstd/__init__.py
@@ -31,7 +31,6 @@ __all__ = (
 
 import backports.zstd._zstd as _zstd
 import enum
-from backports.zstd._shutil import register_shutil
 from backports.zstd._zstd import (ZstdCompressor, ZstdDecompressor, ZstdDict, ZstdError,
                                   get_frame_size, zstd_version)
 from backports.zstd._zstdfile import ZstdFile, open, _nbytes
@@ -247,3 +246,11 @@ class Strategy(enum.IntEnum):
 
 # Check validity of the CompressionParameter & DecompressionParameter types
 _zstd.set_parameter_types(CompressionParameter, DecompressionParameter)
+
+
+# Lazy loading
+def __getattr__(name):
+    if name == "register_shutil":
+        from backports.zstd._shutil import register_shutil
+        return register_shutil
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")


### PR DESCRIPTION
Comments on the [integration in `hatch`](https://github.com/pypa/hatch/pull/2034) pointed that a few milliseconds at import time may matter a bit.

This PR makes the `register_shutil` imported in `backports.zstd` module to be lazy-loaded.

---

Version 1.0.0:

```
# hyperfine --shell none -m 100 --warmup 10 "python -c \"import backports.zstd\"" 
Benchmark 1: python -c "import backports.zstd"
  Time (mean ± σ):      29.8 ms ±   0.5 ms    [User: 24.6 ms, System: 4.8 ms]
  Range (min … max):    28.9 ms …  34.0 ms    101 runs
```

With this PR:
```
# hyperfine --shell none -m 100 --warmup 10 "python -c \"import backports.zstd\"" 
Benchmark 1: python -c "import backports.zstd"
  Time (mean ± σ):      24.4 ms ±   0.4 ms    [User: 20.3 ms, System: 3.8 ms]
  Range (min … max):    23.7 ms …  27.3 ms    120 runs
```