### PR TITLE
Stop building wheels for cp313t

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,7 +62,7 @@ jobs:
       matrix: ${{ steps.define.outputs.matrix }}
       full: ${{ steps.define.outputs.full }}
     env:
-      PYTHON_VERSIONS: cp39 cp310 cp311 cp312 cp313 cp313t pp310 pp311
+      PYTHON_VERSIONS: cp39 cp310 cp311 cp312 cp313 pp310 pp311
       FULL:
         ${{ ( startsWith(github.ref, 'refs/tags') || startsWith(github.head_ref,
         'release-') || github.event_name == 'workflow_dispatch' ) && '1' || '0' }}
@@ -113,7 +113,7 @@ jobs:
     env:
       CIBW_ARCHS: ${{ matrix.archs }}
       CIBW_BUILD: ${{ matrix.build }}
-      CIBW_ENABLE: cpython-freethreading pypy pypy-eol
+      CIBW_ENABLE: pypy pypy-eol
       CIBW_TEST_COMMAND: python -m unittest discover {project}/tests -v
     steps:
       - name: Setup Python

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ adheres to [Semantic Versioning](https://semver.org/).
 ### :rocket: Added
 
 - Update code with CPython 3.14.4 version
+- Stop build wheels for CPython 3.13 free-threading
 
 ## [1.3.0] - 2025-12-29
 


### PR DESCRIPTION
See https://github.com/Quansight-Labs/free-threaded-compatibility/issues/322 for context.

We still support installing on 3.13 free-threading from the sdist.