### PR TITLE
Remove support for 3.9

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -66,7 +66,7 @@ jobs:
       matrix: ${{ steps.define.outputs.matrix }}
       full: ${{ steps.define.outputs.full }}
     env:
-      PYTHON_VERSIONS: cp39 cp310 cp311 cp312 cp313 pp310 pp311
+      PYTHON_VERSIONS: cp310 cp311 cp312 cp313 pp310 pp311
       FULL:
         ${{ ( startsWith(github.ref, 'refs/tags') || startsWith(github.head_ref,
         'release-') || github.event_name == 'workflow_dispatch' ) && '1' || '0' }}
@@ -160,8 +160,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - version: "3.9.0"
-            file_pattern: "*-cp39-cp39-manylinux*x86_64*.whl"
           - version: "3.10.0"
             file_pattern: "*-cp310-cp310-manylinux*x86_64*.whl"
           - version: "3.11.0"
@@ -195,7 +193,6 @@ jobs:
       fail-fast: false
       matrix:
         python:
-          - "3.9"
           - "3.10"
           - "3.11"
           - "3.12"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ adheres to [Semantic Versioning](https://semver.org/).
 
 - Update code with CPython 3.14.4 version
 - Update type hints with typeshed `44dac88`
+- Remove support for CPython 3.9
 - Build wheels for Android
 - Build wheels for iOS
 - Stop build wheels for CPython 3.13 free-threading

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,13 +14,12 @@ classifiers = [
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
 ]
-requires-python = ">=3.9,<3.14"
+requires-python = ">=3.10,<3.14"
 
 [project.urls]
 Homepage = "https://github.com/rogdham/backports.zstd"

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 from setuptools import Extension, setup
 
-if not ((3, 9) <= sys.version_info < (3, 14)):
+if not ((3, 10) <= sys.version_info < (3, 14)):
     raise RuntimeError(f"Unsupported Python version: {sys.version}")
 
 

--- a/src/c/compat/backports_zstd_compat.h
+++ b/src/c/compat/backports_zstd_compat.h
@@ -33,10 +33,4 @@ static inline int PyType_Freeze(PyTypeObject *type)
 #define _PyCFunction_CAST(func) _Py_CAST(PyCFunction, _Py_CAST(void (*)(void), (func)))
 #endif
 
-#if PY_VERSION_HEX < 0x030A0000 // Python 3.9 and below
-// this will not mark objects as immutable
-// but it is acceptable in the scope of this library
-#define Py_TPFLAGS_IMMUTABLETYPE 0
-#endif
-
 #endif /* !BACKPORTS_ZSTD_COMPAT_H */

--- a/src/c/compat/backports_zstd_edits.h
+++ b/src/c/compat/backports_zstd_edits.h
@@ -42,14 +42,7 @@ BACKPORTSZSTD__PyArg_UnpackKeywords(
         buf);
 }
 
-/*
-The implementation of PyNumber_Index in 3.9 is the same as _PyNumber_Index in 3.10
-*/
-#if PY_VERSION_HEX < 0x030A0000 // Python 3.9 and below
-#define BACKPORTSZSTD__PyNumber_Index(o) PyNumber_Index(o)
-#else
 #define BACKPORTSZSTD__PyNumber_Index(o) _PyNumber_Index(o)
-#endif
 
 #if PY_VERSION_HEX < 0x030D0000 // Python 3.12 and below
 #define BACKPORTSZSTD_PyErr_Format_AppendPT(t, s, o) PyErr_Format(t, (s "%s"), Py_TYPE(o)->tp_name)

--- a/src/python/backports/zstd/__init__.py
+++ b/src/python/backports/zstd/__init__.py
@@ -1,7 +1,7 @@
 """Python bindings to the Zstandard (zstd) compression library (RFC-8878)."""
 
 import sys
-if not ((3, 9) <= sys.version_info < (3, 14)):
+if not ((3, 10) <= sys.version_info < (3, 14)):
     raise RuntimeError(f"Unsupported Python version: {sys.version}")
 
 __all__ = (

--- a/src/python/backports/zstd/zipfile/_path/__init__.py
+++ b/src/python/backports/zstd/zipfile/_path/__init__.py
@@ -198,10 +198,7 @@ def _extract_text_encoding(encoding=None, *args, **kwargs):
     # See jaraco/zipp#143
     is_old_pypi = is_pypy and sys.pypy_version_info < (7, 3, 19)
     stack_level = 3 + is_old_pypi
-    if sys.version_info >= (3, 10):
-        return io.text_encoding(encoding, stack_level), args, kwargs
-    else:
-        return encoding or 'locale', args, kwargs
+    return io.text_encoding(encoding, stack_level), args, kwargs
 
 
 class Path:

--- a/tests/test/test_zstd.py
+++ b/tests/test/test_zstd.py
@@ -6,7 +6,6 @@ import random
 import re
 import os
 import unittest
-import sys
 import tempfile
 import threading
 
@@ -1418,9 +1417,8 @@ class ZstdDictTestCase(unittest.TestCase):
             _zstd.finalize_dict(TRAINED_DICT.dict_content, b'', [], 100, 5)
         with self.assertRaises(TypeError):
             _zstd.finalize_dict(TRAINED_DICT.dict_content, b'', (), 100.1, 5)
-        if sys.version_info >= (3, 10):  # emits a warning instead of failing in 3.9
-            with self.assertRaises(TypeError):
-                _zstd.finalize_dict(TRAINED_DICT.dict_content, b'', (), 100, 5.1)
+        with self.assertRaises(TypeError):
+            _zstd.finalize_dict(TRAINED_DICT.dict_content, b'', (), 100, 5.1)
 
         with self.assertRaises(ValueError):
             _zstd.finalize_dict(TRAINED_DICT.dict_content, b'abc', (4, -1), 100, 5)


### PR DESCRIPTION
Version 3.9 has reached end of life [at the end of October 2025](https://devguide.python.org/versions/).