### PR TITLE
Update code from upstream 3.14.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/), and this project
 adheres to [Semantic Versioning](https://semver.org/).
 
+## Unreleased
+
+### :rocket: Added
+
+- Update code with CPython 3.14.5 version
+
 ## [1.4.0] - 2026-05-03
 
 [1.4.0]: https://github.com/rogdham/backports.zstd/releases/tag/v1.4.0

--- a/src/c/compression_zstd/compressor.c
+++ b/src/c/compression_zstd/compressor.c
@@ -76,7 +76,7 @@ zstd_contentsize_converter(PyObject *size, unsigned long long *p)
             if (PyErr_ExceptionMatches(PyExc_OverflowError)) {
                 PyErr_Format(PyExc_ValueError,
                              "size argument should be a positive int less "
-                             "than %ull", ZSTD_CONTENTSIZE_ERROR);
+                             "than %llu", ZSTD_CONTENTSIZE_ERROR);
                 return 0;
             }
             return 0;
@@ -85,7 +85,7 @@ zstd_contentsize_converter(PyObject *size, unsigned long long *p)
             *p = ZSTD_CONTENTSIZE_ERROR;
             PyErr_Format(PyExc_ValueError,
                          "size argument should be a positive int less "
-                         "than %ull", ZSTD_CONTENTSIZE_ERROR);
+                         "than %llu", ZSTD_CONTENTSIZE_ERROR);
             return 0;
         }
         *p = pledged_size;

--- a/src/c/compression_zstd/decompressor.c
+++ b/src/c/compression_zstd/decompressor.c
@@ -113,6 +113,7 @@ _zstd_set_d_parameters(ZstdDecompressor *self, PyObject *options)
         int key_v = PyLong_AsInt(key);
         Py_DECREF(key);
         if (key_v == -1 && PyErr_Occurred()) {
+            Py_DECREF(value);
             return -1;
         }
 

--- a/src/python/backports/zstd/_compat.py
+++ b/src/python/backports/zstd/_compat.py
@@ -1,0 +1,78 @@
+import os
+import sys
+
+if sys.version_info >= (3, 12):
+    os_path_splitroot = os.path.splitroot
+
+elif os.name ==  'posix':
+    # from Lib/posixpath.py
+    def os_path_splitroot(p):
+        """Split a pathname into drive, root and tail.
+
+        The tail contains anything after the root."""
+        p = os.fspath(p)
+        if isinstance(p, bytes):
+            sep = b'/'
+            empty = b''
+        else:
+            sep = '/'
+            empty = ''
+        if p[:1] != sep:
+            # Relative path, e.g.: 'foo'
+            return empty, empty, p
+        elif p[1:2] != sep or p[2:3] == sep:
+            # Absolute path, e.g.: '/foo', '///foo', '////foo', etc.
+            return empty, sep, p[1:]
+        else:
+            # Precisely two leading slashes, e.g.: '//foo'. Implementation defined per POSIX, see
+            # https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap04.html#tag_04_13
+            return empty, p[:2], p[2:]
+
+elif os.name == 'nt':
+    # from Lib/ntpath.py
+    def os_path_splitroot(p):
+        """Split a pathname into drive, root and tail.
+
+        The tail contains anything after the root."""
+        p = os.fspath(p)
+        if isinstance(p, bytes):
+            sep = b'\\'
+            altsep = b'/'
+            colon = b':'
+            unc_prefix = b'\\\\?\\UNC\\'
+            empty = b''
+        else:
+            sep = '\\'
+            altsep = '/'
+            colon = ':'
+            unc_prefix = '\\\\?\\UNC\\'
+            empty = ''
+        normp = p.replace(altsep, sep)
+        if normp[:1] == sep:
+            if normp[1:2] == sep:
+                # UNC drives, e.g. \\server\share or \\?\UNC\server\share
+                # Device drives, e.g. \\.\device or \\?\device
+                start = 8 if normp[:8].upper() == unc_prefix else 2
+                index = normp.find(sep, start)
+                if index == -1:
+                    return p, empty, empty
+                index2 = normp.find(sep, index + 1)
+                if index2 == -1:
+                    return p, empty, empty
+                return p[:index2], p[index2:index2 + 1], p[index2 + 1:]
+            else:
+                # Relative path with root, e.g. \Windows
+                return empty, p[:1], p[1:]
+        elif normp[1:2] == colon:
+            if normp[2:3] == sep:
+                # Absolute drive-letter path, e.g. X:\Windows
+                return p[:2], p[2:3], p[3:]
+            else:
+                # Relative path with drive, e.g. X:Windows
+                return p[:2], empty, p[2:]
+        else:
+            # Relative path, e.g. Windows
+            return empty, empty, p
+
+else:
+    raise ImportError('no os specific module found')

--- a/src/python/backports/zstd/_shutil.py
+++ b/src/python/backports/zstd/_shutil.py
@@ -119,27 +119,9 @@ def _unpack_zipfile(filename, extract_dir):
     if not zipfile.is_zipfile(filename):
         raise ReadError("%s is not a zip file" % filename)
 
-    zip = zipfile.ZipFile(filename)
-    try:
-        for info in zip.infolist():
-            name = info.filename
-
-            # don't extract absolute paths or ones with .. in them
-            if name.startswith('/') or '..' in name:
-                continue
-
-            targetpath = os.path.join(extract_dir, *name.split('/'))
-            if not targetpath:
-                continue
-
-            _ensure_directory(targetpath)
-            if not name.endswith('/'):
-                # file
-                with zip.open(name, 'r') as source, \
-                        open(targetpath, 'wb') as target:
-                    copyfileobj(source, target)
-    finally:
-        zip.close()
+    with zipfile.ZipFile(filename) as zip:
+        zip._ignore_invalid_names = True
+        zip.extractall(extract_dir)
 
 def _unpack_tarfile(filename, extract_dir, *, filter=None):
     """Unpack tar/tar.gz/tar.bz2/tar.xz/tar.zst `filename` to `extract_dir`

--- a/src/python/backports/zstd/zipfile/__init__.py
+++ b/src/python/backports/zstd/zipfile/__init__.py
@@ -32,6 +32,7 @@ except ImportError:
     lzma = None
 
 from backports import zstd
+from backports.zstd._compat import os_path_splitroot
 
 __all__ = ["BadZipFile", "BadZipfile", "error",
            "ZIP_STORED", "ZIP_DEFLATED", "ZIP_BZIP2", "ZIP_LZMA",
@@ -1405,6 +1406,7 @@ class ZipFile:
 
     fp = None                   # Set here since __del__ checks it
     _windows_illegal_name_trans_table = None
+    _ignore_invalid_names = False
 
     def __init__(self, file, mode="r", compression=ZIP_STORED, allowZip64=True,
                  compresslevel=None, *, strict_timestamps=True, metadata_encoding=None):
@@ -1890,21 +1892,31 @@ class ZipFile:
 
         # build the destination pathname, replacing
         # forward slashes to platform specific separators.
-        arcname = member.filename.replace('/', os.path.sep)
-
-        if os.path.altsep:
+        arcname = member.filename
+        if os.path.sep != '/':
+            arcname = arcname.replace('/', os.path.sep)
+        if os.path.altsep and os.path.altsep != '/':
             arcname = arcname.replace(os.path.altsep, os.path.sep)
         # interpret absolute pathname as relative, remove drive letter or
         # UNC path, redundant separators, "." and ".." components.
-        arcname = os.path.splitdrive(arcname)[1]
+        drive, root, arcname = os_path_splitroot(arcname)
+        if self._ignore_invalid_names and (drive or root):
+            return None
+        if self._ignore_invalid_names and os.path.pardir in arcname.split(os.path.sep):
+            return None
         invalid_path_parts = ('', os.path.curdir, os.path.pardir)
         arcname = os.path.sep.join(x for x in arcname.split(os.path.sep)
                                    if x not in invalid_path_parts)
         if os.path.sep == '\\':
             # filter illegal characters on Windows
-            arcname = self._sanitize_windows_name(arcname, os.path.sep)
+            arcname2 = self._sanitize_windows_name(arcname, os.path.sep)
+            if self._ignore_invalid_names and arcname2 != arcname:
+                return None
+            arcname = arcname2
 
         if not arcname and not member.is_dir():
+            if self._ignore_invalid_names:
+                return None
             raise ValueError("Empty filename.")
 
         targetpath = os.path.join(targetpath, arcname)

--- a/sync/cpython.json
+++ b/sync/cpython.json
@@ -19,6 +19,7 @@
   "src/c/compression_zstd/clinic/decompressor.c.h": [
     "Modules/_zstd/clinic/decompressor.c.h"
   ],
+  "src/python/backports/zstd/_compat.py": ["Lib/posixpath.py", "Lib/ntpath.py"],
   "src/python/backports/zstd/_streams.py": ["Lib/compression/_common/_streams.py"],
   "src/python/backports/zstd/__init__.py": ["Lib/compression/zstd/__init__.py"],
   "src/python/backports/zstd/_zstdfile.py": ["Lib/compression/zstd/_zstdfile.py"],

--- a/tests/test/test_zipfile/test_core.py
+++ b/tests/test/test_zipfile/test_core.py
@@ -33,10 +33,6 @@ from test.support.os_helper import (
 from test.support.import_helper import ensure_lazy_imports
 
 
-# backportszstd: specific test conditions
-gh_96290_support = bool(ntpath.splitdrive("\\\\conky\\\\mountpoint\\foo\\bar")[0])
-
-
 TESTFN2 = TESTFN + "2"
 TESTFNDIR = TESTFN + "d"
 FIXEDTEST_SIZE = 1000
@@ -1756,22 +1752,10 @@ class ExtractTests(unittest.TestCase):
             (r'C:\foo\bar', 'foo/bar'),
             (r'//conky/mountpoint/foo/bar', 'foo/bar'),
             (r'\\conky\mountpoint\foo\bar', 'foo/bar'),
-        ]
-        if gh_96290_support:
-            windows_hacknames += [
-                (r'///conky/mountpoint/foo/bar', 'mountpoint/foo/bar'),
-                (r'\\\conky\mountpoint\foo\bar', 'mountpoint/foo/bar'),
-                (r'//conky//mountpoint/foo/bar', 'mountpoint/foo/bar'),
-                (r'\\conky\\mountpoint\foo\bar', 'mountpoint/foo/bar'),
-            ]
-        else:
-            windows_hacknames += [
-                (r'///conky/mountpoint/foo/bar', 'conky/mountpoint/foo/bar'),
-                (r'\\\conky\mountpoint\foo\bar', 'conky/mountpoint/foo/bar'),
-                (r'//conky//mountpoint/foo/bar', 'conky/mountpoint/foo/bar'),
-                (r'\\conky\\mountpoint\foo\bar', 'conky/mountpoint/foo/bar'),
-            ]
-        windows_hacknames += [
+            (r'///conky/mountpoint/foo/bar', 'mountpoint/foo/bar'),
+            (r'\\\conky\mountpoint\foo\bar', 'mountpoint/foo/bar'),
+            (r'//conky//mountpoint/foo/bar', 'mountpoint/foo/bar'),
+            (r'\\conky\\mountpoint\foo\bar', 'mountpoint/foo/bar'),
             (r'//?/C:/foo/bar', 'foo/bar'),
             (r'\\?\C:\foo\bar', 'foo/bar'),
             (r'C:/../C:/foo/bar', 'C_/foo/bar'),
@@ -1915,7 +1899,7 @@ class OtherTests(unittest.TestCase):
                 zip_info = zf.getinfo("test_no_source_date_epoch.txt")
                 current_time = time.localtime()[:6]
                 for z_time, c_time in zip(zip_info.date_time, current_time):
-                    self.assertAlmostEqual(z_time, c_time, delta=1)
+                    self.assertAlmostEqual(z_time, c_time, delta=2)
 
     def test_close(self):
         """Check that the zipfile is closed after the 'with' block."""


### PR DESCRIPTION
Because `zipfile/__init__.py` uses `os.path.splitroot` which was introduced in 3.12, we need to backport that as well for older Python versions.